### PR TITLE
Use the more specific `.atom-text-editor` selector.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,50 +1,50 @@
 @import "syntax-variables";
 
-.editor {
+.atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor .gutter {
+.atom-text-editor .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-.editor .gutter .line-number.cursor-line {
+.atom-text-editor .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .gutter .line-number.cursor-line-no-selection {
+.atom-text-editor .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .wrap-guide {
+.atom-text-editor .wrap-guide {
   color: @syntax-wrap-guide-color;
 }
 
-.editor .indent-guide {
+.atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-.editor .invisible-character {
+.atom-text-editor .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-.editor .search-results .marker .region {
+.atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+.atom-text-editor .search-results .marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-.editor.is-focused .cursor {
+.atom-text-editor.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }
 
-.editor.is-focused .selection .region {
+.atom-text-editor.is-focused .selection .region {
   background-color: @syntax-selection-color;
 }
 
@@ -54,7 +54,7 @@
   border: 1px solid @syntax-bracket-matcher;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+.atom-text-editor.is-focused .line-number.cursor-line-no-selection, .atom-text-editor.is-focused .line.cursor-line {
   background-color: rgba(166, 148, 66, 0);
 }
 


### PR DESCRIPTION
Atom is issuing a deprecation warning for the `.editor` CSS selector.

![screen shot 2015-05-20 at 5 21 53 pm](https://cloud.githubusercontent.com/assets/1817/7739397/e92e9b52-ff14-11e4-8362-8edb69b83696.png)
