### PR TITLE
Reference invisibles character color properly.

### DIFF
--- a/index.less
+++ b/index.less
@@ -27,7 +27,7 @@ atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-atom-text-editor .invisible-character {
+atom-text-editor::shadow .invisible-character {
   color: @syntax-invisible-character-color;
 }
 


### PR DESCRIPTION
According to this GitHub issue, the `atom-text-editor` selector has changed.

https://github.com/atom/atom/issues/4962

Before:

![screen shot 2015-05-22 at 2 06 54 pm](https://cloud.githubusercontent.com/assets/1817/7779738/dd569208-008b-11e5-8ee4-4e29a9e72374.png)

After:

![screen shot 2015-05-22 at 2 03 29 pm](https://cloud.githubusercontent.com/assets/1817/7779717/a7b297b4-008b-11e5-98ca-4609df6e1515.png)
